### PR TITLE
Use the ioDecReader when reading the RPC Array header byte as well, to allow pipelined/async requests to function better.

### DIFF
--- a/codec/decode.go
+++ b/codec/decode.go
@@ -82,16 +82,22 @@ func (z *ioDecReader) readb(bs []byte) {
 	}
 }
 
+func (z *ioDecReader) tryreadn1() (b uint8, err error) {
+        if z.br != nil {
+                b, err = z.br.ReadByte()
+                return
+        }
+        z.readb(z.x[:1])
+        b = z.x[0]
+        return
+}
+
 func (z *ioDecReader) readn1() uint8 {
-	if z.br != nil {
-		b, err := z.br.ReadByte()
-		if err != nil {
-			panic(err)
-		}
-		return b
-	}
-	z.readb(z.x[:1])
-	return z.x[0]
+        b, err := z.tryreadn1()
+        if err != nil {
+                panic(err)
+        }
+        return b
 }
 
 func (z *ioDecReader) readUint16() uint16 {

--- a/codec/msgpack.go
+++ b/codec/msgpack.go
@@ -766,21 +766,17 @@ func (c *msgpackSpecRpcCodec) parseCustomHeader(expectTypeByte byte, msgid *uint
 	// We read the response header by hand
 	// so that the body can be decoded on its own from the stream at a later time.
 
-	bs := make([]byte, 1)
-	n, err := c.rwc.Read(bs)
-	if err != nil {
-		return
-	}
-	if n != 1 {
-		err = fmt.Errorf("Couldn't read array descriptor: No bytes read")
-		return
-	}
+        z := c.dec.r.(*ioDecReader)
+        b, err := z.tryreadn1()
+
+        if err != nil {
+                return
+        }
 	const fia byte = 0x94 //four item array descriptor value
-	if bs[0] != fia {
-		err = fmt.Errorf("Unexpected value for array descriptor: Expecting %v. Received %v", fia, bs[0])
+	if b != fia {
+		err = fmt.Errorf("Unexpected value for array descriptor: Expecting %v. Received %v", fia, b)
 		return
 	}
-	var b byte
 	if err = c.read(&b); err != nil {
 		return
 	}


### PR DESCRIPTION
It looks like the initial array byte in a messagepacked rpc request is currently read directly from the connection, while the rest of the message is read through a buffered reader, for efficiency.  When multiple requests are pipelined together in a series of async requests though, the header byte doesn't seem to get read properly in the pipelined requests.

This fix uses the ioDecReader for the header byte as well, allowing pipelined requests to function again.
# sample client/server which triggers the condition: 

package main

import (
    "github.com/ugorji/go/codec"
    "log"
    "net"
    "net/rpc"
    "os"
    "time"
)

type F struct{}

func (t *F) Square(a int, reply *int) error {
    time.Sleep(1e9)
    *reply = a \* a
    return nil
}

func main() {
    var mh codec.MsgpackHandle

```
if len(os.Args) > 1 && os.Args[1] == "s" { // run server

    testServer := &F{}
    rpc.Register(testServer)

    listener, err := net.Listen("tcp", "127.0.0.1:9090")
    if err != nil {
        panic(err)
    }
    defer listener.Close()

    for {
        conn, err := listener.Accept()
        if err != nil {
            panic(err)
        }
        rpcCodec := codec.MsgpackSpecRpc.ServerCodec(conn, &mh)
        go rpc.ServeCodec(rpcCodec)
    }
} else { // run client

    conn, err := net.Dial("tcp", "localhost:9090")
    if err != nil {
        log.Fatal("dialing:", err)
    }
    client := rpc.NewClientWithCodec(codec.MsgpackSpecRpc.ClientCodec(conn, &mh))

    // with delay, client succeeds
    makeAsyncCalls(client, 3, 1e7)
    // without, client fails
    makeAsyncCalls(client, 10, 0)

}
```

}

func makeAsyncCalls(client _rpc.Client, numCalls int, delay time.Duration) {
    replies := make([]int, numCalls)
    calls := make([]_rpc.Call, numCalls)
    for i, _ := range replies {
        calls[i] = client.Go("F.Square", i, &replies[i], nil)
        time.Sleep(delay)
    }
    for i, _ := range replies {
        done := <-calls[i].Done
        log.Printf("Reply(%v), Channel Value(%v)\n", replies[i], done)
    }
}
