### PR TITLE
codec: handle EOF on last non-zero byte read

### DIFF
--- a/codec/decode.go
+++ b/codec/decode.go
@@ -141,6 +141,10 @@ func (z *ioDecByteScanner) Read(p []byte) (n int, err error) {
 	}
 	n, err = z.r.Read(p)
 	if n > 0 {
+		// Read() can return io.EOF as an error even when
+		// bytes are successfully read. Simplify the error
+		// handling by hiding EOF in this case.
+		err = nil
 		z.l = p[n-1]
 		z.ls = 2
 	}


### PR DESCRIPTION
The io.Reader interface specifies that Read() may return
io.EOF when it encounters the end of the stream, even if
it returns some bytes. Handle this case in the decoder
by setting the error to nil if it reads any bytes.