### PR TITLE
Remove superfluous comparisons

### DIFF
--- a/codec/cbor.go
+++ b/codec/cbor.go
@@ -98,7 +98,7 @@ func (e *cborEncDriver) encUint(v uint64, bd byte) {
 	} else if v <= math.MaxUint32 {
 		e.w.writen1(bd + 0x1a)
 		bigenHelper{e.x[:4], e.w}.writeUint32(uint32(v))
-	} else if v <= math.MaxUint64 {
+	} else {
 		e.w.writen1(bd + 0x1b)
 		bigenHelper{e.x[:8], e.w}.writeUint64(v)
 	}

--- a/codec/json.go
+++ b/codec/json.go
@@ -294,7 +294,7 @@ func (x *jsonNum) uintExp() (n uint64, overflow bool) {
 		return
 	}
 	n *= jsonUint64Pow10[e]
-	if n < x.mantissa || n > jsonNumUintMaxVal {
+	if n < x.mantissa {
 		overflow = true
 		return
 	}
@@ -581,7 +581,7 @@ LOOP:
 				n.mantissa *= 10
 				if v != 0 {
 					n1 := n.mantissa + v
-					if n1 < n.mantissa || n1 > jsonNumUintMaxVal {
+					if n1 < n.mantissa {
 						n.manOverflow = true // n+v overflows
 						break
 					}

--- a/codec/simple.go
+++ b/codec/simple.go
@@ -77,7 +77,7 @@ func (e *simpleEncDriver) encUint(v uint64, bd uint8) {
 	} else if v <= math.MaxUint32 {
 		e.w.writen1(bd + 2)
 		bigenHelper{e.b[:4], e.w}.writeUint32(uint32(v))
-	} else if v <= math.MaxUint64 {
+	} else {
 		e.w.writen1(bd + 3)
 		bigenHelper{e.b[:8], e.w}.writeUint64(v)
 	}


### PR DESCRIPTION
I found four places where there were superfluous comparisons to
math.MaxUint64.  Since 'x <= math.MaxUint64' is true for every single
uint64, it's a no-op and can be omitted.

codec.cbor.go: `v <= math.MaxUint64`; v will *always* be <= math.MaxUint64

json.go: `|| n > jsonNumUintMaxVal`; as jsonNumUintMaxVal is the same as math.MaxUint64 and no uint64 can be greater than the max, this will always evaluate to false.

simple.go: `v <= math.MaxUint64`: same issue as above.

I've run the codec tests successfully.

This PR fixes the issue interacting with go-fuzz reported in #78.