### PR TITLE
Correctly decode deeply nested arrays (etc.)

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -415,6 +415,15 @@ func testInit() {
 			"bool":         true,
 			"LONG STRING":  "123456789012345678901234567890123456789012345678901234567890",
 			"SHORT STRING": "1234567890",
+			"nested": []interface{}{
+				[]interface{}{
+					[]interface{}{
+						[]interface{}{
+							[]interface{}{},
+						},
+					},
+				},
+			},
 		},
 		map[interface{}]interface{}{
 			true:       "true",

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -583,14 +583,16 @@ func (f *decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
 		if d.mtid == 0 || d.mtid == mapIntfIntfTypId {
 			l := len(n.ms)
 			n.ms = append(n.ms, nil)
-			d.decode(&n.ms[l])
-			rvn = reflect.ValueOf(&n.ms[l]).Elem()
+			p := &n.ms[l]
+			d.decode(p)
+			rvn = reflect.ValueOf(p).Elem()
 			n.ms = n.ms[:l]
 		} else if d.mtid == mapStrIntfTypId { // for json performance
 			l := len(n.ns)
 			n.ns = append(n.ns, nil)
-			d.decode(&n.ns[l])
-			rvn = reflect.ValueOf(&n.ns[l]).Elem()
+			p := &n.ns[l]
+			d.decode(p)
+			rvn = reflect.ValueOf(p).Elem()
 			n.ns = n.ns[:l]
 		} else {
 			rvn = reflect.New(d.h.MapType).Elem()
@@ -601,8 +603,9 @@ func (f *decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
 		if d.stid == 0 || d.stid == intfSliceTypId {
 			l := len(n.ss)
 			n.ss = append(n.ss, nil)
-			d.decode(&n.ss[l])
-			rvn = reflect.ValueOf(&n.ss[l]).Elem()
+			p := &n.ss[l]
+			d.decode(p)
+			rvn = reflect.ValueOf(p).Elem()
 			n.ss = n.ss[:l]
 		} else {
 			rvn = reflect.New(d.h.SliceType).Elem()
@@ -615,9 +618,9 @@ func (f *decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
 			l := len(n.is)
 			n.is = append(n.is, nil)
 			v2 := &n.is[l]
-			n.is = n.is[:l]
 			d.decode(v2)
 			v = *v2
+			n.is = n.is[:l]
 		}
 		bfn := d.h.getExtForTag(tag)
 		if bfn == nil {


### PR DESCRIPTION
When decoding "naked" data (to an arbitrary `interface{}`), and handling nested maps and arrays, save a pointer to the slice slot around the recursive call to `decode()`.  Since the recursive call could call `append()` to extend the slice, the underlying storage might move, resulting in a case where we recursively decoded and wrote into the old array, but then return a value from the new array.

Closes: #122