### PR TITLE
Allow disabling code-generation for individual types

### DIFF
--- a/codec/codecgen/README.md
+++ b/codec/codecgen/README.md
@@ -31,6 +31,16 @@ Usage of codecgen:
 % codecgen -o values_codecgen.go values.go values2.go moretypedefs.go
 ```
 
+To disable code generation for specific types, add a `// codecgen:
+skip` comment immediately before its definition. For instance:
+
+```go
+// codecgen: skip
+type struct Foo {
+   Bar string
+}
+```
+
 Please see the [blog article](http://ugorji.net/blog/go-codecgen)
 for more information on how to use the tool.
 


### PR DESCRIPTION
This is inspired by [`// ffjson: skip`](https://github.com/pquerna/ffjson#disabling-code-generation-for-structs)

There are situations in which the user needs/wants to provide custom `Selfer`s for some of the types declared in a file while still being able to automatically generate `Selfer`s for the the rest of the types in that file.

For instance see https://github.com/weaveworks/scope/commit/23ddc1b6dd9a3f8ad3f3efa77beaaffa89a68d30 

I couldn't find an acceptable way to this with the existing implementation:
* The `-r` parameter of `codecgen` is not good enough for excluding types. Regexps are not well suited for negative matching of words. On top of that, Go's regexp implementation intentionally doesn't support lookaheads to comply with its O(n) matching promises, which makes it particularly hard  (see http://stackoverflow.com/questions/2078915/a-regular-expression-to-exclude-a-word-string and https://groups.google.com/d/msg/golang-nuts/7qgSDWPIh_E/OHTAm4wRZL0J )
* I could have split the files in two (types with custom selfers and types without) but this is a horrible solution: structuring the code based on a requirement from a tool.
