### PR TITLE
Fix lint failures in generated type files

### DIFF
--- a/codec/gen.generated.go
+++ b/codec/gen.generated.go
@@ -24,7 +24,7 @@ if {{var "bh"}}.MapValueReset {
 	{{end}} }
 if {{var "l"}} > 0  {
 for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
-	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
+	z.DecSendContainerState(codecSelferContainerMapKey{{ .Sfx }})
 	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
 {{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
 		{{var "mk"}} = string({{var "bv"}})
@@ -36,7 +36,7 @@ for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
 			{{var "ms"}} = false
 		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
 	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
-	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
+	z.DecSendContainerState(codecSelferContainerMapValue{{ .Sfx }})
 	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
 	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
 		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
@@ -44,7 +44,7 @@ for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
 }
 } else if {{var "l"}} < 0  {
 for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
-	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
+	z.DecSendContainerState(codecSelferContainerMapKey{{ .Sfx }})
 	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
 {{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
 		{{var "mk"}} = string({{var "bv"}})
@@ -56,14 +56,14 @@ for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
 			{{var "ms"}} = false
 		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
 	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
-	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
+	z.DecSendContainerState(codecSelferContainerMapValue{{ .Sfx }})
 	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
 	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
 		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
 	}
 }
 } // else len==0: TODO: Should we clear map entries?
-z.DecSendContainerState(codecSelfer_containerMapEnd{{ .Sfx }})
+z.DecSendContainerState(codecSelferContainerMapEnd{{ .Sfx }})
 `
 
 const genDecListTmpl = `


### PR DESCRIPTION
The ugorji go library is used by kubernetes and other related projects.
The changes in this patch takes care of lint failure several, total 90,
lint failures. The main types of failure includes,
1. Superfluous or irrelevant usage of bool variables
2. Generated functions name have underscore in them
3. error var is not in a recommended format
4. Exported functions are missing doc comments
5. Const variables name are using underscore in them

For example, some of the common failure/error messages are:
1. should omit type bool from declaration of var <x>; it will be inferred from the right-hand side
2. don't use underscores in Go names; method <x> should be <y>
3. exported method <x> should have comment or be unexported
4. don't use underscores in Go names; const <x> should be <y>
5.  error var <x> should have name of the form errFoo