### PR TITLE
Allow string interning with msgpack codec

### DIFF
--- a/codec/msgpack.go
+++ b/codec/msgpack.go
@@ -553,7 +553,7 @@ func (d *msgpackDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOu
 }
 
 func (d *msgpackDecDriver) DecodeString() (s string) {
-	return string(d.DecodeBytes(d.b[:], true, true))
+	return d.d.string(d.DecodeBytes(d.b[:], true, true))
 }
 
 func (d *msgpackDecDriver) readNextBd() {


### PR DESCRIPTION
Setting `MsgpackHandle.InternString` when using msgpack would do nothing, since it never went through the necessary code path.