### PR TITLE
handle decoding true/false as strings

### DIFF
--- a/codec/json.go
+++ b/codec/json.go
@@ -988,6 +988,18 @@ func (d *jsonDecDriver) appendStringAsBytes() {
 		return
 	}
 
+	// handle boolean values as strings
+	if d.tok == 'f' {
+		d.readStrIdx(5, 9) // alse
+		d.bs = d.bs[:0]
+		return
+	}
+	if d.tok == 't' {
+		d.readStrIdx(1, 4) // rue
+		d.bs = d.bs[:0]
+		return
+	}
+
 	if d.tok != '"' {
 		d.d.errorf("json: expect char '%c' but got char '%c'", '"', d.tok)
 	}


### PR DESCRIPTION
Addresses cases such as the following:

```go
v := struct{
    Selector map[string]string `json:"selector"`
}{}
```
```json
dataToDecode := `{
    "selector": {
        "field": false
    }
}`
```
```yaml
dataToDecodeAsYAML := `
selector:
  field: no
`
```

where the output struct expects a map of string keys and values, and the input contains non-quoted boolean values.

Particularly in cases where the input is yaml and is later converted into json before being decoded, this patch prevents a potentially confusing error where a user might use a yaml-specific boolean keyword (such as `yes` or `no`), and then is presented with a decoder error similar to `[pos 36]: json: expect char '"' but got char 'f'`

Related downstream bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1458204#c1

cc @fabianofranz