### PR TITLE
Support CBOR struct encode/decode with integer type key element.

### DIFF
--- a/codec/decode.go
+++ b/codec/decode.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"sync"
 	"time"
+	"strconv"
 )
 
 // Some tagging information for error messages.
@@ -218,6 +219,9 @@ type DecodeOptions struct {
 	//
 	// if > 0, we use a smart buffer internally for performance purposes.
 	ReaderBufferSize int
+
+	// use int type key for struct key element
+	UseIntKeyStructDec bool
 }
 
 // ------------------------------------
@@ -1145,9 +1149,16 @@ func (d *Decoder) kStruct(f *codecFnInfo, rv reflect.Value) {
 			if elemsep {
 				dd.ReadMapElemKey()
 			}
-			rvkencnameB := dd.DecodeStringAsBytes()
-			rvkencname := stringView(rvkencnameB)
 			// rvksi := ti.getForEncName(rvkencname)
+			var rvkencname string
+			if (d.h.UseIntKeyStructDec) {
+				// get element as int
+				rvkencname = strconv.Itoa(int(dd.DecodeInt(8)))
+			} else {
+				// get element as string
+				rvkencnameB := dd.DecodeStringAsBytes()
+				rvkencname = stringView(rvkencnameB)
+			}
 			if elemsep {
 				dd.ReadMapElemValue()
 			}

--- a/codec/encode.go
+++ b/codec/encode.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"strconv"
 )
 
 const defEncByteBufSize = 1 << 6 // 4:16, 6:64, 8:256, 10:1024
@@ -170,6 +171,9 @@ type EncodeOptions struct {
 	//
 	// if > 0, we use a smart buffer internally for performance purposes.
 	WriterBufferSize int
+
+	// use int type key for struct key element
+	UseIntKeyStructEnc bool
 }
 
 // ---------------------------------------------
@@ -583,7 +587,17 @@ func (e *Encoder) kStructNoOmitempty(f *codecFnInfo, rv reflect.Value) {
 		if !elemsep {
 			for _, si := range tisfi {
 				if asSymbols {
-					ee.EncodeSymbol(si.encName)
+					if (e.h.UseIntKeyStructEnc) {
+						// Encode symbol as int
+						i, err := strconv.Atoi(si.encName)
+						if err != nil {
+							panic(err)
+						}
+						ee.EncodeInt(int64(i))
+					} else {
+						// Encode symbol
+						ee.EncodeSymbol(si.encName)
+					}
 				} else {
 					ee.EncodeString(cUTF8, si.encName)
 				}
@@ -593,7 +607,17 @@ func (e *Encoder) kStructNoOmitempty(f *codecFnInfo, rv reflect.Value) {
 			for _, si := range tisfi {
 				ee.WriteMapElemKey()
 				if asSymbols {
-					ee.EncodeSymbol(si.encName)
+					if (e.h.UseIntKeyStructEnc) {
+						// Encode symbol as int
+						i, err := strconv.Atoi(si.encName)
+						if err != nil {
+							panic(err)
+						}
+						ee.EncodeInt(int64(i))
+					} else {
+						// Encode symbol
+						ee.EncodeSymbol(si.encName)
+					}
 				} else {
 					ee.EncodeString(cUTF8, si.encName)
 				}
@@ -698,7 +722,17 @@ func (e *Encoder) kStruct(f *codecFnInfo, rv reflect.Value) {
 			for j := 0; j < newlen; j++ {
 				kv = fkvs[j]
 				if asSymbols {
-					ee.EncodeSymbol(kv.v)
+					if (e.h.UseIntKeyStructEnc) {
+						// Encode symbol as int
+						i, err := strconv.Atoi(kv.v)
+						if err != nil {
+							panic(err)
+						}
+						ee.EncodeInt(int64(i))
+					} else {
+						// Encode symbol
+						ee.EncodeSymbol(kv.v)
+					}
 				} else {
 					ee.EncodeString(cUTF8, kv.v)
 				}
@@ -709,7 +743,17 @@ func (e *Encoder) kStruct(f *codecFnInfo, rv reflect.Value) {
 				kv = fkvs[j]
 				ee.WriteMapElemKey()
 				if asSymbols {
-					ee.EncodeSymbol(kv.v)
+					if (e.h.UseIntKeyStructEnc) {
+						// Encode symbol as int
+						i, err := strconv.Atoi(kv.v)
+						if err != nil {
+							panic(err)
+						}
+						ee.EncodeInt(int64(i))
+					} else {
+						// Encode symbol
+						ee.EncodeSymbol(kv.v)
+					}
 				} else {
 					ee.EncodeString(cUTF8, kv.v)
 				}


### PR DESCRIPTION
Could you support integer type key when encoding/decoding golang struct to cbor.

For example: golang struct
```
type Animal struct {
    Name string `codec:"1"`
    Age  int `codec:"2"`
}
```

--> cbor binary, mapping Name as 1(int) and Age as 2(2)
```
00000000  a2 01 64 68 6f 67 65 02  05                       |..dhoge..|
```

Because, DOTS specification required integer type cbor key element.
https://datatracker.ietf.org/doc/draft-ietf-dots-signal-channel/
`
6.  Mapping Parameters to CBOR
`

Sample code:
```
package main

// go get github.com/gonuts/cbor

import (
	"bytes"
	"encoding/hex"
	"fmt"

	"github.com/ugorji/go/codec"
)

type Animal struct {
    Name string `codec:"1"`
    Age  int `codec:"2"`
}

func convertCBOR(v Animal) {
	buf := new(bytes.Buffer)

	cborHandle := new(codec.CborHandle)
	// Set new config for Struct key int type mapping
	cborHandle.UseIntKeyStructEnc = true
	cborHandle.UseIntKeyStructDec = true

	// encode struct --> cbor
	enc := codec.NewEncoder(buf, cborHandle)
	err := enc.Encode(v)
	if err != nil {
		panic(err)
	}
	fmt.Printf("%s\n", hex.Dump(buf.Bytes()))

	// decode cbor --> struct
	var vDec Animal
	dec := codec.NewDecoder(buf, cborHandle)
	err2 := dec.Decode(&vDec)
	if err2 != nil {
		panic(err2)
	}
	fmt.Printf("decoded=\n%+v\n", vDec)
}

func main() {
	v := Animal{ Name:"hoge", Age: 5}
	// Test CBOR
	convertCBOR(v)
}
```