### PR TITLE
Drop hostname in codec test

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1150,7 +1150,7 @@ func testCodecRpcOne(t *testing.T, rr Rpc, h Handle, doRequest bool, exitSleepMs
 	}
 	srv := rpc.NewServer()
 	srv.Register(testRpcInt)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", ":0")
 	// log("listener: %v", ln.Addr())
 	checkErrT(t, err)
 	port = (ln.Addr().(*net.TCPAddr)).Port


### PR DESCRIPTION
Drop the 127.0.0.1 in the codec test to make the test ipv6 compliant.

(it will no longer be listening on localhost explicitly, i'm happy to revert this if you're uncomfortable with that).