### PR TITLE
moved go.mod to root level

### DIFF
--- a/codec/go.mod
+++ b/codec/go.mod
@@ -1,2 +1,0 @@
-module github.com/ugorji/go/codec
-

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,2 @@
+module github.com/ugorji/go
+


### PR DESCRIPTION
I believe the go.mod file that you have at the child level is causing issue when go modules is used outside the GOPATH.  Here's what happens when I attempt to use gin-gonic:

```
../../../go/pkg/mod/github.com/gin-gonic/gin@v1.3.0/binding/msgpack.go:12:2: unknown import path "github.com/ugorji/go/codec": ambiguous import: found github.com/ugorji/go/codec in multiple modules:
	github.com/ugorji/go v1.1.1 (/Users/matt/go/pkg/mod/github.com/ugorji/go@v1.1.1/codec)
	github.com/ugorji/go/codec v0.0.0-20180831062425-e253f1f20942 (/Users/matt/go/pkg/mod/github.com/ugorji/go/codec@v0.0.0-20180831062425-e253f1f20942)
```

I think what's happening is that it's considering the go.mod file you put in the codec directory a separate module that's in conflict with github.com/ugorji/go/codec.