### PR TITLE
json DecodeNaked empty string error add keyword

### DIFF
--- a/codec/json.go
+++ b/codec/json.go
@@ -1203,7 +1203,7 @@ func (d *jsonDecDriver) DecodeNaked() {
 	default: // number
 		bs := d.decNumBytes()
 		if len(bs) == 0 {
-			d.d.errorf("decode number from empty string")
+			d.d.errorf("decode number from empty string. key: %s", d.bsToString())
 			return
 		}
 		if err := d.nakedNum(z, bs); err != nil {


### PR DESCRIPTION
When I parse a very big json file.
If there's not critical information，it's very difficult to troubleshoot problems.
So, I add this code.