### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/codec/test.py
+++ b/codec/test.py
@@ -11,6 +11,7 @@
 
 # Ensure all "string" keys are utf strings (else encoded as bytes)
 
+from __future__ import print_function
 import cbor, msgpack, msgpackrpc, sys, os, threading
 
 def get_test_data_list():
@@ -69,13 +70,11 @@ def build_test_data(destdir):
     for i in range(len(l)):
         # packer = msgpack.Packer()
         serialized = msgpack.dumps(l[i])
-        f = open(os.path.join(destdir, str(i) + '.msgpack.golden'), 'wb')
-        f.write(serialized)
-        f.close()
+        with open(os.path.join(destdir, str(i) + '.msgpack.golden'), 'wb') as f:
+            f.write(serialized)
         serialized = cbor.dumps(l[i])
-        f = open(os.path.join(destdir, str(i) + '.cbor.golden'), 'wb')
-        f.write(serialized)
-        f.close()
+        with open(os.path.join(destdir, str(i) + '.cbor.golden'), 'wb') as f:
+            f.write(serialized)
 
 def doRpcServer(port, stopTimeSec):
     class EchoHandler(object):
@@ -98,15 +97,15 @@ def doRpcServer(port, stopTimeSec):
 def doRpcClientToPythonSvc(port):
     address = msgpackrpc.Address('127.0.0.1', port)
     client = msgpackrpc.Client(address, unpack_encoding='utf-8')
-    print client.call("Echo123", "A1", "B2", "C3")
-    print client.call("EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"})
+    print(client.call("Echo123", "A1", "B2", "C3"))
+    print(client.call("EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"}))
    
 def doRpcClientToGoSvc(port):
-    # print ">>>> port: ", port, " <<<<<"
+    # print(">>>> port: ", port, " <<<<<")
     address = msgpackrpc.Address('127.0.0.1', port)
     client = msgpackrpc.Client(address, unpack_encoding='utf-8')
-    print client.call("TestRpcInt.Echo123", ["A1", "B2", "C3"])
-    print client.call("TestRpcInt.EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"})
+    print(client.call("TestRpcInt.Echo123", ["A1", "B2", "C3"]))
+    print(client.call("TestRpcInt.EchoStruct", {"A" :"Aa", "B":"Bb", "C":"Cc"}))
 
 def doMain(args):
     if len(args) == 2 and args[0] == "testdata":
@@ -123,4 +122,3 @@ def doMain(args):
     
 if __name__ == "__main__":
     doMain(sys.argv[1:])
-


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Also, use __with open() as__ context manager syntax to automate file.close() even in the face of exceptions.