### PR TITLE
Correctly handle literal \ufffd chars when encoding JSON

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -3372,6 +3372,17 @@ func TestJsonInvalidUnicode(t *testing.T) {
 	}
 }
 
+func TestJsonUnicodeReplacementChar(t *testing.T) {
+	s := "a�b"
+	bs, err := testMarshal(s, testJsonH)
+	if err != nil {
+		t.Errorf("bad marshal: %s", err)
+	}
+	if string(bs) != `"a�b"` {
+		t.Errorf("Bad encoding, expected %q, got %s", s, string(bs))
+	}
+}
+
 func TestMsgpackDecodeMapAndExtSizeMismatch(t *testing.T) {
 	fn := func(t *testing.T, b []byte, v interface{}) {
 		if err := NewDecoderBytes(b, testMsgpackH).Decode(v); err != io.EOF && err != io.ErrUnexpectedEOF {


### PR DESCRIPTION
Fixes #313.
Fixes #317.

utf8.DecodeRuneInString uses this rune to signal errors, but it can also be present as a literal rune in the string.

Without this fix, encoding a string that contains `�` results in an infinite loop. I wasn't sure where the best place to extend the tests would be; adding a string with this rune in it to the `primitives` list at the top causes tests involving other encoders to fail.