### PR TITLE
Fix wrong logic in IsCodecEmpty code generation

### DIFF
--- a/codec/gen.go
+++ b/codec/gen.go
@@ -650,10 +650,10 @@ func (x *genRunner) tryGenIsZero(t reflect.Type) (done bool) {
 		// if Ptr, we already checked if nil above
 		if t2.Type.Kind() != reflect.Ptr {
 			x.doEncOmitEmptyLine(t2, varname, &omitline)
-			omitline.s(" && ")
+			omitline.s(" || ")
 		}
 	}
-	omitline.s(" true")
+	omitline.s(" false")
 	x.linef("return !(%s)", omitline.v())
 
 	x.line("}")


### PR DESCRIPTION
For the following types:

```go
type S struct {
	A string
	B string
}

type User struct {
	MaybeEmpty S `json:",omitempty"`
}
```

The following code was generated:
```go
func (x *S) IsCodecEmpty() bool {
	return !(x.A != "" && x.B != "" && true)
}
```

Now we generate:

```go
func (x *S) IsCodecEmpty() bool {
	return !(x.A != "" || x.B != "" || false)
}
```

Should fix https://github.com/ugorji/go/issues/344