### PR TITLE
Fix the noFrac code to handle `0`.

### DIFF
--- a/codec/decimal.go
+++ b/codec/decimal.go
@@ -132,12 +132,20 @@ var fi64 = floatinfo{52, 22, 15, false, 1<<52 - 1}
 var fi64u = floatinfo{0, 19, 0, true, fUint64Cutoff}
 
 func noFrac64(fbits uint64) bool {
+	if fbits == 0 {
+		return true
+	}
+
 	exp := uint64(fbits>>52)&0x7FF - 1023 // uint(x>>shift)&mask - bias
 	// clear top 12+e bits, the integer part; if the rest is 0, then no fraction.
 	return exp < 52 && fbits<<(12+exp) == 0 // means there's no fractional part
 }
 
 func noFrac32(fbits uint32) bool {
+	if fbits == 0 {
+		return true
+	}
+
 	exp := uint32(fbits>>23)&0xFF - 127 // uint(x>>shift)&mask - bias
 	// clear top 9+e bits, the integer part; if the rest is 0, then no fraction.
 	return exp < 23 && fbits<<(9+exp) == 0 // means there's no fractional part


### PR DESCRIPTION
In f4b40f6 code was added to allow reading a (non-fraction-containing)
float64 into a uint64 struct. This code depends on a new function
noFrac64 to decide if the cast is legal. (There is also a noFrac32.)
However, noFrac64 and noFrac32 do not return the correct result when
the input is 0.0. In that case, subtracting the bias yields a negative
number (which is then interpreted as a very large positive number).

I don't know if there's a way to fix this without adding a new
comparison function (like replacing the subtraction of the bias with a
bitwise operation of some sort or another), but this fix is simple
enough.  I didn't see any tests for this code so I didn't add a test
for it.

Fixes #364