### PR TITLE
Skip type aliases

### DIFF
--- a/codec/codecgen/gen.go
+++ b/codec/codecgen/gen.go
@@ -332,6 +332,7 @@ func mainGen(tv *mainCfg, infiles ...string) (err error) {
 							//   - it doesn't have any of the Selfer methods in the file
 							if tv.regexName.FindStringIndex(td.Name.Name) != nil &&
 								tv.notRegexName.FindStringIndex(td.Name.Name) == nil &&
+								!td.Assign.IsValid() &&
 								!selferEncTyps[td.Name.Name] &&
 								!selferDecTyps[td.Name.Name] {
 								tv.Types = append(tv.Types, td.Name.Name)


### PR DESCRIPTION
Hi, when you define `type A = B`, `A` becomes an alias of `B`.

Instead, using `type A B`, `B` is an underlying object of `A`.

For the former, the generator incorrectly generates duplicated `selfer` methods causing the go code to be invalid.

Regards,
Mauro