### PR TITLE
Added support for go 1.13+ error wrapping.

### DIFF
--- a/codec/helper.go
+++ b/codec/helper.go
@@ -617,6 +617,11 @@ func (e *codecError) Cause() error {
 	return e.err
 }
 
+// Unwrap implements support for go1.13+ error wrapping
+func (e *codecError) Unwrap() error {
+	return e.err
+}
+
 func (e *codecError) Error() string {
 	if e.encode {
 		return fmt.Sprintf("%s encode error: %v", e.name, e.err)


### PR DESCRIPTION
Go 1.13 introduced an [error wrapping mechanism](https://go.dev/blog/go1.13-errors) that is similar, but incompatible with `pkg/errors`. This PR adds the `(*codecError).Unwrap()` method so that methods like `errors.Is()` work correctly.
