### PR TITLE
cbor: use fmtTime instead of time.Format for RFC3339Nano

### DIFF
--- a/codec/cbor.go
+++ b/codec/cbor.go
@@ -204,7 +204,11 @@ func (e *cborEncDriver) EncodeTime(t time.Time) {
 		e.EncodeNil()
 	} else if e.h.TimeRFC3339 {
 		e.encUint(0, cborBaseTag)
-		e.encStringBytesS(cborBaseString, t.Format(time.RFC3339Nano))
+		const fmt = time.RFC3339Nano
+		bs := e.e.blist.get(len(fmt))
+		bs = fmtTime(t, fmt, bs) // size bounded: no chance of realloc.
+		e.encStringBytesS(cborBaseString, stringView(bs))
+		e.e.blist.put(bs)
 	} else {
 		e.encUint(1, cborBaseTag)
 		t = t.UTC().Round(time.Microsecond)

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -2803,7 +2803,7 @@ func freelistCapacity(length int) (capacity int) {
 // bytesFreelist is a list of byte buffers, sorted by cap.
 //
 // In anecdotal testing (running go test -tsd 1..6), we couldn't get
-// the length ofthe list > 4 at any time. So we believe a linear search
+// the length of the list > 4 at any time. So we believe a linear search
 // without bounds checking is sufficient.
 //
 // Typical usage model:
@@ -2821,7 +2821,7 @@ func freelistCapacity(length int) (capacity int) {
 //	v1 := v0
 //	... use v1 ...
 //	blist.put(v1)
-//	if byteSliceAddr(v0) != byteSliceAddr(v1) {
+//	if !byteSliceSameData(v0, v1) {
 //	  blist.put(v0)
 //	}
 type bytesFreelist [][]byte


### PR DESCRIPTION
This may save an allocation per string-formatted timestamp,
particularly by reusing a byte slice from blist.
