### PR TITLE
CBOR: Reject malformed and invalid indefinite-length strings

### DIFF
--- a/codec/cbor_test.go
+++ b/codec/cbor_test.go
@@ -61,8 +61,8 @@ func TestCborIndefiniteLength(t *testing.T) {
 	buf.WriteByte(cborBdBreak)
 
 	buf.WriteByte(cborBdIndefiniteString)
-	e.MustEncode([]byte("two-")) // encode as bytes, to check robustness of code
-	e.MustEncode([]byte("value"))
+	e.MustEncode("two-")
+	e.MustEncode("value")
 	buf.WriteByte(cborBdBreak)
 
 	//----

--- a/codec/cbor_test.go
+++ b/codec/cbor_test.go
@@ -92,6 +92,22 @@ func TestCborIndefiniteLength(t *testing.T) {
 	}
 }
 
+// "If any definite-length text string inside an indefinite-length text string is invalid, the
+// indefinite-length text string is invalid. Note that this implies that the UTF-8 bytes of a single
+// Unicode code point (scalar value) cannot be spread between chunks: a new chunk of a text string
+// can only be started at a code point boundary."
+func TestCborIndefiniteLengthTextStringChunksAreUTF8(t *testing.T) {
+	defer testSetup(t, nil)()
+	var handle CborHandle
+	handle.ValidateUnicode = true
+
+	var out string
+	err := NewDecoderBytes([]byte{cborBdIndefiniteString, 0x61, 0xc2, 0x61, 0xa3, cborBdBreak}, &handle).Decode(&out)
+	if err == nil {
+		t.Errorf("expected error but decoded to: %q", out)
+	}
+}
+
 type testCborGolden struct {
 	Base64     string      `codec:"cbor"`
 	Hex        string      `codec:"hex"`


### PR DESCRIPTION
Tests and potential fix for https://github.com/ugorji/go/issues/403 and https://github.com/ugorji/go/issues/404.

Makes decode return a error if a byte string is nested within an indefinite-length text string, or a text string is nested within an indefinite-length byte string. Separately, if the decode option ValidateUnicode is enabled, it will also apply to text strings that are nested within an indefinite-length text string.