### PR TITLE
A 16-bit truncated offset causes large structs to fail to encode or decode correctly

### DIFF
--- a/codec/binc_test.go
+++ b/codec/binc_test.go
@@ -145,3 +145,7 @@ func TestBincDesc(t *testing.T) {
 func TestBincStructFieldInfoToArray(t *testing.T) {
 	doTestStructFieldInfoToArray(t, testBincH)
 }
+
+func TestBincLargeStruct(t *testing.T) {
+	doTestLargeStruct(t, testBincH)
+}

--- a/codec/cbor_test.go
+++ b/codec/cbor_test.go
@@ -637,3 +637,7 @@ func TestCborAllEncCircularRef(t *testing.T) {
 func TestCborAllAnonCycle(t *testing.T) {
 	doTestAnonCycle(t, testCborH)
 }
+
+func TestCborLargeStruct(t *testing.T) {
+	doTestLargeStruct(t, testCborH)
+}

--- a/codec/codec_run_test.go
+++ b/codec/codec_run_test.go
@@ -4183,3 +4183,39 @@ func testEqualH(v1, v2 interface{}, h Handle) (err error) {
 // 		}
 // 	}
 // }
+
+func doTestLargeStruct(t *testing.T, h Handle) {
+
+	const size = 65536
+
+	type LargeStruct struct {
+		A [size]string
+		B [size]int
+		C [size]string
+	}
+
+	a := new(LargeStruct)
+	b := new(LargeStruct)
+
+	for i := range a.A {
+		a.A[i] = fmt.Sprintf("a-%d", i)
+		a.B[i] = i
+		a.C[i] = fmt.Sprintf("c-%d", i)
+	}
+
+	var buf []byte
+	err := NewEncoderBytes(&buf, h).Encode(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewDecoderBytes(buf, h).Decode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(a, b) {
+		t.Error("a != b")
+	}
+
+}

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -1462,11 +1462,11 @@ func (o intf2impls) intf2impl(rtid uintptr) (rv reflect.Value) {
 }
 
 type structFieldInfoNode struct {
-	offset   uint16
+	offset   uintptr
 	index    uint16
 	kind     uint8
 	numderef uint8
-	_        uint16 // padding
+	_        uint32 // padding
 
 	typ reflect.Type
 }
@@ -2374,7 +2374,7 @@ LOOP:
 						parent: path,
 						structFieldInfoNode: structFieldInfoNode{
 							typ:      f.Type,
-							offset:   uint16(f.Offset),
+							offset:   f.Offset,
 							index:    j,
 							kind:     uint8(fkind),
 							numderef: numderef,
@@ -2423,7 +2423,7 @@ LOOP:
 
 		si.node = structFieldInfoNode{
 			typ:      f.Type,
-			offset:   uint16(f.Offset),
+			offset:   f.Offset,
 			index:    j,
 			kind:     uint8(fkind),
 			numderef: numderef,

--- a/codec/json_test.go
+++ b/codec/json_test.go
@@ -802,3 +802,7 @@ func TestJsonAllErrWriter(t *testing.T) {
 func TestJsonTimeAndBytesOptions(t *testing.T) {
 	doTestJsonTimeAndBytesOptions(t, testJsonH)
 }
+
+func TestJsonLargeStruct(t *testing.T) {
+	doTestLargeStruct(t, testJsonH)
+}

--- a/codec/msgpack_test.go
+++ b/codec/msgpack_test.go
@@ -256,3 +256,7 @@ func TestMsgpackStructFieldInfoToArray(t *testing.T) {
 func TestMsgpackDecodeMapAndExtSizeMismatch(t *testing.T) {
 	doTestMsgpackDecodeMapAndExtSizeMismatch(t, testMsgpackH)
 }
+
+func TestMsgpackLargeStruct(t *testing.T) {
+	doTestLargeStruct(t, testMsgpackH)
+}

--- a/codec/simple_test.go
+++ b/codec/simple_test.go
@@ -142,3 +142,7 @@ func TestSimpleMultipleEncDec(t *testing.T) {
 func TestSimpleAllErrWriter(t *testing.T) {
 	doTestAllErrWriter(t, testSimpleH)
 }
+
+func TestSimpleLargeStruct(t *testing.T) {
+	doTestLargeStruct(t, testSimpleH)
+}


### PR DESCRIPTION
In unsafe mode, truncating field offsets can lead to accesses to memory addresses that do not belong to those fields. If, during encoding, this may result only in an incorrectly serialized representation, then during decoding - especially when the struct contains reference fields - pointer corruption may occur.

The proposed fix removes the truncation of offsets and eliminates the risk of incorrect memory access.