### PR TITLE
fix CBOR Tag 4/5 decoding - use 0x82 instead of decimal 82 for 2-elem…

### DIFF
--- a/codec/cbor.go
+++ b/codec/cbor.go
@@ -659,7 +659,7 @@ func (d *cborDecDriver[T]) decTagBigIntAsFloat(neg bool) (f float64) {
 }
 
 func (d *cborDecDriver[T]) decTagBigFloatAsFloat(decimal bool) (f float64) {
-	if nn := d.r.readn1(); nn != 82 {
+	if nn := d.r.readn1(); nn != 0x82 {
 		halt.errorf("(%d) decoding decimal/big.Float: expected 2 numbers", nn)
 	}
 	exp := d.DecodeInt64()

--- a/codec/cbor.mono.generated.go
+++ b/codec/cbor.mono.generated.go
@@ -1,4 +1,4 @@
-//go:build !notmono && !codec.notmono 
+//go:build !notmono && !codec.notmono
 
 // Copyright (c) 2012-2020 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
@@ -3701,7 +3701,7 @@ func (d *cborDecDriverBytes) decTagBigIntAsFloat(neg bool) (f float64) {
 }
 
 func (d *cborDecDriverBytes) decTagBigFloatAsFloat(decimal bool) (f float64) {
-	if nn := d.r.readn1(); nn != 82 {
+	if nn := d.r.readn1(); nn != 0x82 {
 		halt.errorf("(%d) decoding decimal/big.Float: expected 2 numbers", nn)
 	}
 	exp := d.DecodeInt64()
@@ -7683,7 +7683,7 @@ func (d *cborDecDriverIO) decTagBigIntAsFloat(neg bool) (f float64) {
 }
 
 func (d *cborDecDriverIO) decTagBigFloatAsFloat(decimal bool) (f float64) {
-	if nn := d.r.readn1(); nn != 82 {
+	if nn := d.r.readn1(); nn != 0x82 {
 		halt.errorf("(%d) decoding decimal/big.Float: expected 2 numbers", nn)
 	}
 	exp := d.DecodeInt64()

--- a/codec/cbor_test.go
+++ b/codec/cbor_test.go
@@ -609,6 +609,34 @@ func TestCborNumbers(t *testing.T) {
 	doTestNumbers(t, testCborH)
 }
 
+func TestCborDecimalFraction(t *testing.T) {
+	if !testRecoverPanicToErr {
+		t.Skip(testSkipIfNotRecoverPanicToErrMsg)
+	}
+	var h Handle = testCborH
+	defer testSetup(t, &h)()
+
+	// tag 4 (decimal fraction): 273.15 = 27315 * 10^(-2)
+	// c4=tag(4), 82=array(2), 21=negint(-2), 19 6ab3=uint(27315)
+	decFrac := []byte{0xc4, 0x82, 0x21, 0x19, 0x6a, 0xb3}
+	var v1 interface{}
+	NewDecoderBytes(decFrac, h).MustDecode(&v1)
+	f1, ok := v1.(float64)
+	if !ok || f1 != 273.15 {
+		t.Fatalf("tag 4 decimal fraction: got %v (%T), want 273.15", v1, v1)
+	}
+
+	// tag 5 (bigfloat): 1.5 = 3 * 2^(-1)
+	// c5=tag(5), 82=array(2), 20=negint(-1), 03=uint(3)
+	bigFloat := []byte{0xc5, 0x82, 0x20, 0x03}
+	var v2 interface{}
+	NewDecoderBytes(bigFloat, h).MustDecode(&v2)
+	f2, ok := v2.(float64)
+	if !ok || f2 != 1.5 {
+		t.Fatalf("tag 5 bigfloat: got %v (%T), want 1.5", v2, v2)
+	}
+}
+
 func TestCborDesc(t *testing.T) {
 	m := make(map[byte]string)
 	for k, v := range cbordescMajorNames {


### PR DESCRIPTION
The function decTagBigFloat at cbor.go:662 checks nn!= 82 (decimal) but should check nn!=0x82 (decimal 130). 
Since the CBOR byte for a 2-element array is 0x82 = 130, the check always fails (130) decoding decimal/big.Float: expected 2 numbers