### PR TITLE
codec: fix crash decoding slice-of-struct-with-map used as a map value

### DIFF
--- a/codec/gh_transient_slice_test.go
+++ b/codec/gh_transient_slice_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2012-2020 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package codec
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestGH437: a []struct-with-a-map used as a map value must round-trip.
+//
+// Regression: isCanTransient marked any top-level slice transient without
+// checking its element, so a []T whose element holds a map/pointer field reused
+// the decoder transient scratch and was corrupted on decode (nil-pointer deref
+// / SIGSEGV in typedmemclr). Re-fixes the regression of #367.
+func TestGH437(t *testing.T) {
+	type P struct {
+		X string
+		N int64
+	}
+	type Item struct {
+		S string
+		M map[int64][]P
+	}
+
+	in := map[string][]Item{"a": {{S: "s", M: map[int64][]P{7: {{X: "x", N: 1}}}}}}
+
+	var h CborHandle
+	var b []byte
+	NewEncoderBytes(&b, &h).MustEncode(in)
+
+	var out map[string][]Item
+	NewDecoderBytes(b, &h).MustDecode(&out)
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch:\n in: %#v\nout: %#v", in, out)
+	}
+}

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -1994,7 +1994,13 @@ func isCanTransient(t reflect.Type, inclStrSlice bool) (v bool) {
 	if inclStrSlice {
 		bset = &numBoolStrSliceBitset
 	}
-	if bset.isset(byte(k)) {
+	if k == reflect.Slice {
+		// A slice is transient-safe only when its element is itself a
+		// non-reference scalar (number/bool). Otherwise the element (e.g. a
+		// struct with a map/pointer field) may be zeroed through a transient
+		// pointer into reused slice-backing memory, corrupting it. See #367.
+		v = inclStrSlice && isCanTransient(t.Elem(), false)
+	} else if bset.isset(byte(k)) {
 		v = true
 	} else if k == reflect.Array {
 		v = isCanTransient(t.Elem(), false)


### PR DESCRIPTION
Fixes #437.

`isCanTransient` (`codec/helper.go`) marked **any** top-level slice as transient without inspecting its element type — unlike arrays and structs, which recurse into the element. A `[]T` whose element holds a map/pointer field was then reused as the decoder's transient scratch, and the live element got zeroed through a stale pointer into reused slice-backing memory: a nil-pointer dereference, or an unrecoverable SIGSEGV in `runtime.typedmemclr` under other memory layouts.

This restores the element check that #367 introduced and that was lost in the v1.3.0 reorganization: a slice is transient only when its element is itself a non-reference scalar, mirroring the existing `reflect.Array` handling.

​```go
if k == reflect.Slice {
	v = inclStrSlice && isCanTransient(t.Elem(), false)
} else if bset.isset(byte(k)) {
	...
​```

Added `TestGH437` (`codec/gh_transient_slice_test.go`): round-trips `map[string][]Item` where `Item` has a map field — panics without the fix, passes with it. Verified with `go test ./codec -run TestGH437` on go1.26.
